### PR TITLE
add scope tests for class methods

### DIFF
--- a/powershell/helpers.Tests.ps1
+++ b/powershell/helpers.Tests.ps1
@@ -1,0 +1,39 @@
+. "$PSScriptRoot\helpers.ps1"
+
+Describe New-Psm1File {
+    Mock Get-TempPsm1Path { 'path' }-Verifiable
+    Mock Set-Content -Verifiable
+    It 'returns path' {
+        $r = New-Psm1File name {'scriptblock'}
+        $r | Should be 'path'
+    }
+    It 'invokes commands' {
+        Assert-MockCalled Get-TempPsm1Path 1 {
+            $Name -eq 'name'
+        }
+        Assert-MockCalled Set-Content 1 {
+            $Value -eq "'scriptblock'" -and
+            $Path -eq 'path'
+        }
+    }
+}
+
+Describe New-Psm1Module {
+    Mock New-Psm1File {'path'} -Verifiable
+    Mock Import-Module { 'module info' } -Verifiable
+    It 'returns module info' {
+        $r = New-Psm1Module name {'scriptblock'} -ArgumentList 'args'
+        $r | Should be 'module info'
+    }
+    It 'invokes commands' {
+        Assert-MockCalled New-Psm1File 1 {
+            [string]$Scriptblock -eq "'scriptblock'"# -and
+            $Name -eq 'name'
+        }
+        Assert-MockCalled Import-Module 1 {
+            $Name -eq 'path' -and
+            $ArgumentList -eq 'args' -and
+            $PassThru
+        }
+    }
+}

--- a/powershell/helpers.ps1
+++ b/powershell/helpers.ps1
@@ -1,0 +1,67 @@
+$tempPsm1Guid = 'b3cd95fc-1569-4170-a1f4-4eb50efbe289'
+
+function Get-TempPsm1Path
+{
+    param
+    (
+        [Parameter(Mandatory = $true,
+                   ValueFromPipeline = $true)]
+        $Name
+    )
+    process
+    {
+        "$([System.IO.Path]::GetTempPath())$Name.psm1"
+    }
+}
+
+function New-Psm1Module 
+{
+    # keeping parity with the signature of `New-Module` would
+    # go a long way to performing pairs of tests using dynamic
+    # and file-backed modules
+    param
+    (
+        [Parameter(Mandatory = $true,
+                   ValueFromPipeline = $true,
+                   Position = 1)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true,
+                   Position = 2)]
+        [scriptblock]
+        $Scriptblock,
+
+        [Object[]]
+        $ArgumentList
+    )
+    process
+    {
+        $Name | 
+            New-Psm1File -Scriptblock $Scriptblock | 
+            Import-Module -ArgumentList $ArgumentList -PassThru
+    }
+}
+
+function New-Psm1File
+{
+    param
+    (
+        [Parameter(Mandatory = $true,
+                   ValueFromPipeline = $true,
+                   Position = 1)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true,
+                   Position = 2)]
+        [scriptblock]
+        $Scriptblock
+    )
+    process
+    {
+        $path = $Name | Get-TempPsm1Path
+        [string]$Scriptblock | Set-Content $path
+        $path
+    }
+}


### PR DESCRIPTION
@nohwnd Here is part of the tests you asked me to implement.  Note the following:

* I added [a call to `Export-ModuleMember`](https://github.com/nohwnd/Mock/compare/master...alx9r:master#diff-15faae48b5b4218355cf13c171ed3788R80) which caused some of the existing tests to fail.  I _think_ this is because something is relying on functions being exported when it probably shouldn't.
* PowerShell itself seems to have some unexpected behavior with respect to the scope of the class method scriptblocks.  I think that is currently confounding some of the new tests which try to invoke functions from a class method.  That requires some more investigation.